### PR TITLE
fixed ability to log time to the project with turned off timelog module

### DIFF
--- a/app/views/spent_time/create_entry.js.erb
+++ b/app/views/spent_time/create_entry.js.erb
@@ -1,5 +1,5 @@
 $("#flash_notice").remove()
 $("#flash_error").remove()
-$("#content").prepend("<div class='flash notice' id='flash_notice'><%=l(flash[:notice])%></div>")
+$("#content").prepend("<div class='flash notice' id='flash_notice'><%=flash[:notice]%></div>")
 $('#time_entries_report').html("<%= escape_javascript(render :partial => 'time_entries_report') %>")
 $("#flash_notice").fadeOut(7000)

--- a/app/views/spent_time/create_entry_error.js.erb
+++ b/app/views/spent_time/create_entry_error.js.erb
@@ -1,3 +1,3 @@
 $("#flash_notice").remove()
 $("#flash_error").remove()
-$("#content").prepend("<div class='flash error' id='flash_error'><%=l(flash[:error])%></div>")
+$("#content").prepend("<div class='flash error' id='flash_error'><%=flash[:error]%></div>")

--- a/app/views/spent_time/index.html.erb
+++ b/app/views/spent_time/index.html.erb
@@ -23,7 +23,7 @@
       <%= radio_button_tag('period_type', '1', !@free_period) %>
       <%= select_tag('period', options_for_period_select(params[:period]),
                                :onchange => "$('form_query').onsubmit();".html_safe,
-                               :onfocus => "$('period_type_1').checked = true;".html_safe) %>
+                               :onfocus => "$user_projects_ordered('period_type_1').checked = true;".html_safe) %>
       <%= radio_button_tag('period_type', '2', @free_period) %>
       <span onclick="$('period_type_2').checked = true;">
         <%= l(:label_date_from) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,4 +16,7 @@ en:
   time_entry_added_notice: "Time entry added"
   invalid_date_error: "Invalid date format"
   invalid_hours_error: "Invalid hours format"
-  
+  not_allowed_error: "It's not allowed to log time to project '%{project}'"
+  issue_not_in_project_error: "Issue #%{issue} isn't in project '%{project}'"
+  issue_not_found_error: "Issue with id=%{issue_id} not found"
+  cannot_find_project_error: "Cannot find project with id=%{project_id}"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -10,3 +10,7 @@ ru:
   select_project_option: "Выберите проект"
   label_person: "Пользователь"
   label_interval: "Интервал"
+  not_allowed_error: "Запрещено логировать на проект '%{project}'"
+  issue_not_in_project_error: "Тикет #%{issue} находится не в проекте '%{project}'"
+  issue_not_found_error: "Тикет id=%{issue_id} не найден"
+  cannot_find_project_error: "Нет проекта с id=%{project_id}"


### PR DESCRIPTION
Added check if user is allowed to log time to the project. The issue occurs, because User.current.projects doesn't check if time logging module is available.

Additional fixes:
1. moved localization from erb templates to ruby scripts in order to show parametrized strings
2. added more error checks when creating time entry
