### PR TITLE
Fix for bug #78 undefined method `order' for #Array:0x007f4694c18950

### DIFF
--- a/app/controllers/spent_time_controller.rb
+++ b/app/controllers/spent_time_controller.rb
@@ -22,7 +22,7 @@ class SpentTimeController < ApplicationController
       projects = User.current.projects
       projects.each { |project| @users.concat(project.users) }
       @users.uniq!
-      @users.order(:firstname)
+      @users.sort!
     else
       @users = [@user]
     end


### PR DESCRIPTION
Changed the line in spent_time_controller.rb that was giving the error:
undefined method `order' for #Array:0x007f4694c18950
when a user with permission to "view others spent time" tries to access
the Spent Time from menu.

Works for me in:
Redmine 3.3.0
Ruby 2.2.3
Rails 4.2.6
