### PR TITLE
date is no longer reset to today when changing project on time entry

### DIFF
--- a/app/helpers/spent_time_helper.rb
+++ b/app/helpers/spent_time_helper.rb
@@ -45,7 +45,7 @@ module SpentTimeHelper
   def render_project_tree
     select_tag('project_id', "<option value='-1'>-#{l(:select_project_option)}</option>".html_safe +
         project_tree_options_for_select(user_projects_ordered),
-               {:onchange => "$.post('#{spent_time_update_project_issues_path(:from => @from, :to => @to)}', {'_method':'post', 'project_id':this.value});".html_safe})
+               {:onchange => "$.post('#{spent_time_update_project_issues_path(:from => @from, :to => @to)}', {'_method':'post', 'project_id':this.value, 'spent_on':$('#time_entry_spent_on').val()});".html_safe})
   end
 
   # Returns the users' projects ordered by name

--- a/app/views/spent_time/_fields_for_new_entry_form.html.erb
+++ b/app/views/spent_time/_fields_for_new_entry_form.html.erb
@@ -8,7 +8,7 @@
                    options_for_select([[l(:select_issues_option), 0]] + @assigned_issues.collect { |i| ["##{i.id} - #{i.subject}".html_safe, i.id] }), :style => 'width:250px') %>
   <% end -%>
   <%= l(:label_date) %>
-  <%= date_field_tag('time_entry_spent_on', if Date.today >= @from && Date.today <= @to then Date.today else '' end, :size => 10) %> <%= calendar_for('time_entry_spent_on') %>
+  <%= date_field_tag('time_entry_spent_on', if params[:spent_on] == '' then Date.today else params[:spent_on] end, :size => 10) %> <%= calendar_for('time_entry_spent_on') %>
   <%= l(:label_activity) %>
   <%= select(:time_entry, :activity_id, activities_for_select)%>
   <%= l(:field_hours) %>


### PR DESCRIPTION
The currently set date is added to the parameters send when changing the project in the select list in spent_time_helpers.rb.

This value is used in _fields_for_new_entry_form.html.erb as the value for the newly shown datefield after changing the project. If not present, the value defaults to todays date.