### PR TITLE
Make day length (in hours) configurable

### DIFF
--- a/app/helpers/spent_time_helper.rb
+++ b/app/helpers/spent_time_helper.rb
@@ -93,6 +93,7 @@ module SpentTimeHelper
     }
     @assigned_issues = []
     @activities = TimeEntryActivity.all
+    @day_length = @plugin_setting ||= Setting.plugin_redmine_spent_time['spent_time_day_length']
   end
 
   # Retrieves the date range based on predefined ranges or specific from/to param dates

--- a/app/views/settings/_spent_time_settings.html.erb
+++ b/app/views/settings/_spent_time_settings.html.erb
@@ -1,4 +1,4 @@
 <p>
-<label>l(:label_day_length)</label>
+<label><%= l(:label_day_length) %></label>
 <%= text_field_tag 'settings[spent_time_day_length]', @settings['spent_time_day_length'] %>
 </p>

--- a/app/views/settings/_spent_time_settings.html.erb
+++ b/app/views/settings/_spent_time_settings.html.erb
@@ -1,0 +1,4 @@
+<p>
+<label>l(:label_day_length)</label>
+<%= text_field_tag 'settings[spent_time_day_length]', @settings['spent_time_day_length'] %>
+</p>

--- a/app/views/spent_time/_time_entries_by_date.html.erb
+++ b/app/views/spent_time/_time_entries_by_date.html.erb
@@ -9,10 +9,10 @@
   <%
     total_hours = (@entries_by_date[day].nil? ? 0 : @entries_by_date[day].sum(&:hours).to_f)
     style = 'hours'
-    if total_hours < 8.0
-        style = 'less_than_8_hours'
-    elsif total_hours > 8.0
-        style = 'more_than_8_hours'
+    if total_hours < @day_length.to_f && !is_weekend
+        style = 'less_than_day_length'
+    elsif total_hours > @day_length.to_f && !is_weekend
+        style = 'more_than_day_length'
     end
   %>
   <td class="<%= style %> centered"><em><%= format_hours(total_hours) %></em></td>

--- a/assets/stylesheets/spent_time.css
+++ b/assets/stylesheets/spent_time.css
@@ -16,7 +16,7 @@ td.issue-hours {
     font-size: 0.9em;
 }
 
-td.less_than_8_hours {
+td.less_than_day_length {
     text-align: right;
     padding-right: 0.5em;
     font-weight: bold;
@@ -24,7 +24,7 @@ td.less_than_8_hours {
     font-size: 0.9em;
 }
 
-td.more_than_8_hours {
+td.more_than_day_length {
     text-align: right;
     padding-right: 0.5em;
     font-weight: bold;

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -23,3 +23,4 @@ ca:
   cannot_find_project_error: "Cannot find project with id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -23,3 +23,4 @@ cs:
   cannot_find_project_error: "Nelze nalézt projekt s id=%{project_id}"
   project_is_mandatory_error: "Musíte vybrat projekt"
   label_total_estimated_time: "Celková odhadovaná doba"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -23,3 +23,4 @@ de:
   cannot_find_project_error: "Es kann kein Projekt mit der id=%{project_id} gefunden werden"
   project_is_mandatory_error: "Es muss ein Projekt ausgewählt werden"
   label_total_estimated_time: "Gesamtzeit geschätzt"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -23,3 +23,4 @@ el:
   cannot_find_project_error: "Δεν βρέθηκε έργο με id=%{project_id}"
   project_is_mandatory_error: "Η επιλογή έργου είναι υποχρεωτική"
   label_total_estimated_time: "Συνολικός εκτιμώμενος χρόνος"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,3 +23,4 @@ en:
   cannot_find_project_error: "Cannot find project with id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -23,3 +23,4 @@ es:
   cannot_find_project_error: "El proyecto con id=%{project_id} no existe"
   project_is_mandatory_error: "Debes seleccionar un proyecto"
   label_total_estimated_time: "Tiempo total estimado"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -23,3 +23,4 @@ fr:
   cannot_find_project_error: "Impossible de trouver le projet avec l'id=%{project_id}"
   project_is_mandatory_error: "Vous devez sélectionner un projet"
   label_total_estimated_time: "Temps total estimé"
+  label_day_length: "Durée de la journée (en heures)"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -23,4 +23,5 @@ hu:
   cannot_find_project_error: "Cannot find project with id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_day_length: "Day length (in hours)"
 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -23,3 +23,4 @@ it:
   cannot_find_project_error: "Progetto con id=%{project_id} non trovato"
   project_is_mandatory_error: "Devi selezionare un progetto"
   label_total_estimated_time: "Tempo totale stimato"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,3 +22,4 @@
   cannot_find_project_error: "プロジェクトが見つかりませんでした id=%{project_id}"
   project_is_mandatory_error: "プロジェクトを選んでください"
   label_total_estimated_time: "予定時間"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -23,3 +23,4 @@ pl:
   cannot_find_project_error: "Nie ma projektu o id=%{project_id}"
   project_is_mandatory_error: "Musisz najpierw wybrać projekt"
   label_total_estimated_time: "Łączny szacowany czas"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -23,3 +23,4 @@ pt-BR:
   cannot_find_project_error: "Não é possível encontrar projeto com id=%{project_id}"
   project_is_mandatory_error: "Você precisa selecionar um projeto"
   label_total_estimated_time: "Tempo estimado total"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -23,4 +23,5 @@ pt:
   cannot_find_project_error: "Não é possível encontrar projeto com id=%{project_id}"
   project_is_mandatory_error: "Você precisa selecionar um projeto"
   label_total_estimated_time: "Tempo estimado total"
+  label_day_length: "Day length (in hours)"
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -23,3 +23,4 @@ ru:
   cannot_find_project_error: "Нет проекта с id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_day_length: "Day length (in hours)"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -26,3 +26,4 @@ zh:
   cannot_find_project_error: "ID为 %{project_id} 的项目不存在！"
   project_is_mandatory_error: "您必须选择一个项目！"
   label_total_estimated_time: "总计预估时间"
+  label_day_length: "Day length (in hours)"

--- a/init.rb
+++ b/init.rb
@@ -13,8 +13,11 @@ Redmine::Plugin.register :redmine_spent_time do
   permission :view_spent_time, {:spent_time => [:index]}
   permission :view_others_spent_time, {:spent_time => [:index]}
   permission :view_every_project_spent_time, {:spent_time => [:index]}
+  settings :default => {
+      'spent_time_day_length' => 8
+  }, :partial => 'spent_time_settings'
 
-  menu(:top_menu, 
+  menu(:top_menu,
        :spent_time,
        {:controller => 'spent_time', :action => 'index'},
        :caption => :spent_time_title,


### PR DESCRIPTION
By default day length used to display total time entries in red or blue is hard coded in view (value : 8.0)
This PR allow to define it in plugin settings.

This is my first development in Ruby, I hope I make it well

Thanks