### PR TITLE
Add missing label label_all_time

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -23,3 +23,4 @@ ca:
   cannot_find_project_error: "Cannot find project with id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_all_time: "Tot el temps"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -23,3 +23,4 @@ cs:
   cannot_find_project_error: "Nelze nalézt projekt s id=%{project_id}"
   project_is_mandatory_error: "Musíte vybrat projekt"
   label_total_estimated_time: "Celková odhadovaná doba"
+  label_all_time: "Vše"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -23,3 +23,4 @@ de:
   cannot_find_project_error: "Es kann kein Projekt mit der id=%{project_id} gefunden werden"
   project_is_mandatory_error: "Es muss ein Projekt ausgewählt werden"
   label_total_estimated_time: "Gesamtzeit geschätzt"
+  label_all_time: "Gesamter Zeitraum"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -23,3 +23,4 @@ el:
   cannot_find_project_error: "Δεν βρέθηκε έργο με id=%{project_id}"
   project_is_mandatory_error: "Η επιλογή έργου είναι υποχρεωτική"
   label_total_estimated_time: "Συνολικός εκτιμώμενος χρόνος"
+  label_all_time: "Δυνέχεια"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,3 +23,4 @@ en:
   cannot_find_project_error: "Cannot find project with id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_all_time: "All time"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -23,3 +23,4 @@ es:
   cannot_find_project_error: "El proyecto con id=%{project_id} no existe"
   project_is_mandatory_error: "Debes seleccionar un proyecto"
   label_total_estimated_time: "Tiempo total estimado"
+  label_all_time: "Todo el tiempo"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -23,3 +23,4 @@ fr:
   cannot_find_project_error: "Impossible de trouver le projet avec l'id=%{project_id}"
   project_is_mandatory_error: "Vous devez sélectionner un projet"
   label_total_estimated_time: "Temps total estimé"
+  abel_all_time: "Toute la période"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -23,4 +23,5 @@ hu:
   cannot_find_project_error: "Cannot find project with id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_all_time: "Mindenkor"
 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -23,3 +23,4 @@ it:
   cannot_find_project_error: "Progetto con id=%{project_id} non trovato"
   project_is_mandatory_error: "Devi selezionare un progetto"
   label_total_estimated_time: "Tempo totale stimato"
+  label_all_time: "Sempre"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,3 +22,4 @@
   cannot_find_project_error: "プロジェクトが見つかりませんでした id=%{project_id}"
   project_is_mandatory_error: "プロジェクトを選んでください"
   label_total_estimated_time: "予定時間"
+  label_all_time: "全期間"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -23,3 +23,4 @@ pl:
   cannot_find_project_error: "Nie ma projektu o id=%{project_id}"
   project_is_mandatory_error: "Musisz najpierw wybrać projekt"
   label_total_estimated_time: "Łączny szacowany czas"
+  label_all_time: "Cały czas"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -23,3 +23,4 @@ pt-BR:
   cannot_find_project_error: "Não é possível encontrar projeto com id=%{project_id}"
   project_is_mandatory_error: "Você precisa selecionar um projeto"
   label_total_estimated_time: "Tempo estimado total"
+  label_all_time: "Tudo"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -23,4 +23,5 @@ pt:
   cannot_find_project_error: "Não é possível encontrar projeto com id=%{project_id}"
   project_is_mandatory_error: "Você precisa selecionar um projeto"
   label_total_estimated_time: "Tempo estimado total"
+  label_all_time: "Sempre"
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -23,3 +23,4 @@ ru:
   cannot_find_project_error: "Нет проекта с id=%{project_id}"
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
+  label_all_time: "Всё время"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -26,3 +26,4 @@ zh:
   cannot_find_project_error: "ID为 %{project_id} 的项目不存在！"
   project_is_mandatory_error: "您必须选择一个项目！"
   label_total_estimated_time: "总计预估时间"
+  label_all_time: "全部时间"


### PR DESCRIPTION
I saw that the label `label_all_time` is missing in Redmine ([36191](https://www.redmine.org/issues/36191)). It turned out that it was removed in Redmine itself, as it not used there anymore ([30466](https://www.redmine.org/issues/30466)).

As it is still used in this plugin ([cf. spent_time_helber.rb](https://github.com/eyp/redmine_spent_time/blob/c1a6df960ac3842e6661b0a175fb52016b2b72da/app/helpers/spent_time_helper.rb#L160)), it has to be added to the plugin's locales. Label was added for all the locales available here. The translations were picked from Redmine Revision [r17836](https://www.redmine.org/projects/redmine/repository/revisions/17836).