### PR TITLE
v4.2.0: Redmine 6.x/7.0 support added, tests fixed

### DIFF
--- a/app/helpers/spent_time_helper.rb
+++ b/app/helpers/spent_time_helper.rb
@@ -146,7 +146,7 @@ module SpentTimeHelper
     end
 
     @from, @to = @to, @from if @from && @to && @from > @to
-    @from ||= (TimeEntry.minimum(:spent_on, :include => :project, :conditions => Project.allowed_to_condition(User.current, :view_time_entries)) || Date.today) - 1
+    @from ||= (TimeEntry.joins(:project).where(Project.allowed_to_condition(User.current, :view_time_entries)).minimum(:spent_on) || Date.today) - 1
     @to ||= Date.today
   end
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -24,3 +24,5 @@ ca:
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
   label_all_time: "Tot el temps"
+  label_date_from: "Des de"
+  label_date_to: "A"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -24,3 +24,5 @@ cs:
   project_is_mandatory_error: "Musíte vybrat projekt"
   label_total_estimated_time: "Celková odhadovaná doba"
   label_all_time: "Vše"
+  label_date_from: "Od"
+  label_date_to: "Do"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -24,3 +24,5 @@ de:
   project_is_mandatory_error: "Es muss ein Projekt ausgewählt werden"
   label_total_estimated_time: "Gesamtzeit geschätzt"
   label_all_time: "Gesamter Zeitraum"
+  label_date_from: "Von"
+  label_date_to: "Bis"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -24,3 +24,5 @@ el:
   project_is_mandatory_error: "Η επιλογή έργου είναι υποχρεωτική"
   label_total_estimated_time: "Συνολικός εκτιμώμενος χρόνος"
   label_all_time: "Δυνέχεια"
+  label_date_from: "Από"
+  label_date_to: "Έως"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,5 @@ en:
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
   label_all_time: "All time"
+  label_date_from: "From"
+  label_date_to: "To"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -24,3 +24,5 @@ es:
   project_is_mandatory_error: "Debes seleccionar un proyecto"
   label_total_estimated_time: "Tiempo total estimado"
   label_all_time: "Todo el tiempo"
+  label_date_from: "Desde"
+  label_date_to: "Hasta"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -23,4 +23,6 @@ fr:
   cannot_find_project_error: "Impossible de trouver le projet avec l'id=%{project_id}"
   project_is_mandatory_error: "Vous devez sélectionner un projet"
   label_total_estimated_time: "Temps total estimé"
-  abel_all_time: "Toute la période"
+  label_all_time: "Toute la période"
+  label_date_from: "Du"
+  label_date_to: "Au"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -24,4 +24,6 @@ hu:
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
   label_all_time: "Mindenkor"
+  label_date_from: "Kezdet:"
+  label_date_to: "Vége:"
 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -24,3 +24,5 @@ it:
   project_is_mandatory_error: "Devi selezionare un progetto"
   label_total_estimated_time: "Tempo totale stimato"
   label_all_time: "Sempre"
+  label_date_from: "Da"
+  label_date_to: "A"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,3 +23,5 @@
   project_is_mandatory_error: "プロジェクトを選んでください"
   label_total_estimated_time: "予定時間"
   label_all_time: "全期間"
+  label_date_from: "日付指定: "
+  label_date_to: "から"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -24,3 +24,5 @@ pl:
   project_is_mandatory_error: "Musisz najpierw wybrać projekt"
   label_total_estimated_time: "Łączny szacowany czas"
   label_all_time: "Cały czas"
+  label_date_from: "Od"
+  label_date_to: "Do"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -24,3 +24,5 @@ pt-BR:
   project_is_mandatory_error: "Você precisa selecionar um projeto"
   label_total_estimated_time: "Tempo estimado total"
   label_all_time: "Tudo"
+  label_date_from: "De"
+  label_date_to: "Para"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -24,4 +24,6 @@ pt:
   project_is_mandatory_error: "Você precisa selecionar um projeto"
   label_total_estimated_time: "Tempo estimado total"
   label_all_time: "Sempre"
+  label_date_from: "De"
+  label_date_to: "A"
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -24,3 +24,5 @@ ru:
   project_is_mandatory_error: "You must select a project"
   label_total_estimated_time: "Total estimated time"
   label_all_time: "Всё время"
+  label_date_from: "С"
+  label_date_to: "по"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -27,3 +27,5 @@ zh:
   project_is_mandatory_error: "您必须选择一个项目！"
   label_total_estimated_time: "总计预估时间"
   label_all_time: "全部时间"
+  label_date_from: "从"
+  label_date_to: "到"

--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :redmine_spent_time do
   name 'Redmine Spent Time plugin'
   author 'Eduardo Yáñez Parareda'
   description 'Redmine\'s plugin to show and load projects\' spent time'
-  version '4.2.0'
+  version '4.2.1'
   requires_redmine '4.0'
   url 'https://github.com/eyp/redmine_spent_time'
   author_url 'https://www.linkedin.com/in/eduardoyanez'

--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :redmine_spent_time do
   name 'Redmine Spent Time plugin'
   author 'Eduardo Yáñez Parareda'
   description 'Redmine\'s plugin to show and load projects\' spent time'
-  version '4.1.0'
+  version '4.2.0'
   requires_redmine '4.0'
   url 'https://github.com/eyp/redmine_spent_time'
   author_url 'https://www.linkedin.com/in/eduardoyanez'

--- a/release-notes.rdoc
+++ b/release-notes.rdoc
@@ -1,4 +1,9 @@
 == Release notes
+<b>4.2.0 - 2026-07-23</b>
+* Compatibility with Redmine 6.1 and 7.0 (Rails 7.2, Ruby 3.3)
+* Fix: replaced removed ActiveRecord finder option +minimum(column, :include/:conditions)+ with modern +joins/where+ query (broke the "all time" period)
+* Tests: fixed plugin test_helper load path and added functional tests for the spent time report
+
 <b>3.1.2 - 2015-10-01</b>
 * #77 Refactored routes.rb and fixed projects combo box (@alexandermeindl).
 

--- a/release-notes.rdoc
+++ b/release-notes.rdoc
@@ -1,4 +1,8 @@
 == Release notes
+<b>4.2.1 - 2026-07-29</b>
+* Fix: "Translation missing: en.label_date_from / en.label_date_to" on the report and new entry forms under Redmine 7.0, which dropped both keys from core locales (redmine.org patch #44065). They are now shipped by the plugin itself.
+* Fix: typo +abel_all_time+ in the French locale, which made the "all time" period fall back to English.
+
 <b>4.2.0 - 2026-07-23</b>
 * Compatibility with Redmine 6.1 and 7.0 (Rails 7.2, Ruby 3.3)
 * Fix: replaced removed ActiveRecord finder option +minimum(column, :include/:conditions)+ with modern +joins/where+ query (broke the "all time" period)

--- a/test/functional/spent_time_controller_test.rb
+++ b/test/functional/spent_time_controller_test.rb
@@ -29,4 +29,25 @@ class SpentTimeControllerTest < Redmine::ControllerTest
     post :report, params: { user: 2, from: (Date.today - 7).to_s, to: Date.today.to_s }, xhr: true
     assert_response :success
   end
+
+  def test_index_renders_no_missing_translations
+    get :index
+    assert_response :success
+    missing = response.body.scan(/translation missing:?\s*[\w.]*/i)
+    assert_empty missing, "Untranslated keys rendered: #{missing.uniq.join(', ')}"
+  end
+
+  # Redmine 7.0 dropped label_date_from/label_date_to from its core locales
+  # (redmine.org patch #44065), so the plugin has to ship them itself.
+  def test_shipped_locales_define_the_labels_not_provided_by_core
+    files = Dir[File.expand_path('../../config/locales/*.yml', __dir__)].sort
+    assert_not_empty files
+    files.each do |file|
+      translations = YAML.safe_load(File.read(file, encoding: 'bom|utf-8'))
+      locale = translations.keys.first
+      %w(label_date_from label_date_to label_all_time).each do |key|
+        assert translations[locale].key?(key), "#{File.basename(file)} is missing #{key}"
+      end
+    end
+  end
 end

--- a/test/functional/spent_time_controller_test.rb
+++ b/test/functional/spent_time_controller_test.rb
@@ -1,8 +1,32 @@
-require File.dirname(__FILE__) + '/../test_helper'
+require_relative '../test_helper'
 
-class SpentTimeControllerTest < ActionController::TestCase
-  # Replace this with your real tests.
-  def test_truth
-    assert true
+class SpentTimeControllerTest < Redmine::ControllerTest
+  include Redmine::I18n
+
+  def setup
+    super
+    Setting.default_language = 'en'
+    @request.session[:user_id] = 1
+  end
+
+  def test_index
+    get :index
+    assert_response :success
+  end
+
+  def test_index_with_period
+    get :index, params: { period: '30_days' }
+    assert_response :success
+  end
+
+  def test_index_with_all_period
+    get :index, params: { period: 'all', period_type: '1' }
+    assert_response :success
+  end
+
+  def test_report
+    get :index
+    post :report, params: { user: 2, from: (Date.today - 7).to_s, to: Date.today.to_s }, xhr: true
+    assert_response :success
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,2 @@
-# Load the normal Rails helper
-require File.expand_path(File.dirname(__FILE__) + '/../../../../test/test_helper')
-
-# Ensure that we are using the temporary fixture path
-Engines::Testing.set_fixture_path
+# Load the Redmine helper
+require File.expand_path('../../../../test/test_helper', __FILE__)


### PR DESCRIPTION
<b>4.2.0 - 2026-07-23</b>
* Compatibility with Redmine 6.1 and 7.0 (Rails 7.2, Ruby 3.3)
* Fix: replaced removed ActiveRecord finder option +minimum(column, :include/:conditions)+ with modern +joins/where+ query (broke the "all time" period)
* Tests: fixed plugin test_helper load path and added functional tests for the spent time report